### PR TITLE
style: change design of messages, blockquotes

### DIFF
--- a/src/components/MessagesView/MessageSent.tsx
+++ b/src/components/MessagesView/MessageSent.tsx
@@ -22,7 +22,7 @@ export function MessageSent(props: {
             className={"message_" + props.author}
             style={{
                 backgroundColor:
-                    props.author === "self" ? props.messageColor : "grey",
+                    props.author === "self" ? props.messageColor : "#3B3B3D",
             }}
         >
             <Markdown

--- a/src/components/MessagesView/Messages.scss
+++ b/src/components/MessagesView/Messages.scss
@@ -12,6 +12,7 @@ https://www.gnu.org/licenses/gpl-3.0.html
     display: flex;
     flex-direction: column-reverse;
     overflow: auto;
+    font-size: 15px;
 }
 
 .message-system {
@@ -24,8 +25,8 @@ https://www.gnu.org/licenses/gpl-3.0.html
 
 @mixin common_message_traits($alignment) {
     max-width: 65%;
-    padding: 1px 10px;
-    margin: 10px;
+    padding: 0 15px;
+    margin: 4px 10px;
     overflow-wrap: anywhere;
 }
 
@@ -44,12 +45,12 @@ https://www.gnu.org/licenses/gpl-3.0.html
 
 .message_self {
     @include common_message_traits(flex-end);
-    border-radius: 10px 10px 0 10px;
+    border-radius: 25px 25px 2px 25px;
 }
 
 .message_other {
     @include common_message_traits(flex-start);
-    border-radius: 10px 10px 10px 0;
+    border-radius: 25px 25px 25px 2px;
 }
 
 .message-toolbar {

--- a/src/index.scss
+++ b/src/index.scss
@@ -20,8 +20,9 @@ https://www.gnu.org/licenses/gpl-3.0.html
     }
 
     blockquote {
-        border-left: 5px solid #c7c7c7;
+        border-left: 5px solid #636367;
         padding: 0.5px 20px 0.5px 20px;
+        margin: 20px 10px;
     }
 
     ::-webkit-scrollbar {


### PR DESCRIPTION
The current design looks, IMO, ugly. I want to try to modernize it a little bit.

A few things I want to complete before release:

- [x] Redesign messages UI
- [ ] Cover Markdown cases
  - [ ] Disable headers
  - [ ] Add proper padding/margins to lists
  - [ ] Disable horizontal lines?
  - [ ] Disable code blocks?
  - [ ] Disable tables
  - [ ] Look into images -- disable?
- [ ] Fix #40 
- [ ] Design buttons for the settings
- [ ] Consider having timestamps always visible on messages?